### PR TITLE
Enable content-type specific rendering for attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage_reports
 
 # Translations
 *.mo
@@ -51,5 +52,8 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# Development
+.env
 
 test_app/static

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django==1.7.1
+dj-database-url==0.3.0
+django-jsonfield==0.9.13
+git+https://github.com/sarumont/py-trello.git@766c90dc1dacd2e3fcfc579079a6aab38be43aef
+psycopg2==2.5.4

--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,0 +1,3 @@
+{% load render_filters %}
+<strong>{{action.memberCreator.initials}}</strong> added attachment <strong><a href="{{action.data.attachment.url}}">{{action.data.attachment|render_attachment}}</a></strong>
+{% include 'trello_webhooks/partials/card_link.html' %}

--- a/test_app/templatetags/__init__.py
+++ b/test_app/templatetags/__init__.py
@@ -1,0 +1,4 @@
+from . import render_filters
+
+# For Coverage.
+__all__ = ['render_filters']

--- a/test_app/templatetags/render_filters.py
+++ b/test_app/templatetags/render_filters.py
@@ -1,0 +1,20 @@
+from django import template
+from django.utils.html import format_html
+
+
+register = template.Library()
+
+
+@register.filter
+def render_attachment(attachment):
+    """Render a Trello attachment as HTML.
+
+    If the content type is supported, this will render the attachment
+    with the known renderer; if not, it will simply render its name.
+    """
+    content_type = attachment.get('mimeType', '')
+    url = attachment.get('url', '')
+    name = attachment.get('name', '')
+    if content_type and content_type.startswith('image/'):
+        return format_html('<img src="{}" alt="{}">', url, name)
+    return '"{}"'.format(name)

--- a/test_app/tests/test_render_filters.py
+++ b/test_app/tests/test_render_filters.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+
+from test_app.templatetags import render_filters
+
+
+class RenderAttachmentTests(TestCase):
+
+    def test_image_content_type(self):
+        attachment = {
+            'name': 'example.png',
+            'url': 'https://www.example.com/example.png',
+            'mimeType': 'image/png',
+        }
+        self.assertEqual(
+            render_filters.render_attachment(attachment),
+            '<img src="https://www.example.com/example.png" alt="example.png">'
+        )
+
+    def test_undefined_content_type(self):
+        attachment = {
+            'name': 'undefined',
+            'url': 'https://www.example.com/undefined',
+            'mimeType': None,
+        }
+        self.assertEqual(
+            render_filters.render_attachment(attachment),
+            '"undefined"'
+        )
+
+    def test_unknown_content_type(self):
+        attachment = {
+            'name': 'example.html',
+            'url': 'https://www.example.com/example.html',
+            'mimeType': 'text/html',
+        }
+        self.assertEqual(
+            render_filters.render_attachment(attachment),
+            '"example.html"'
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,5 @@ deps =
     mock==1.0.1
     coverage==3.7.1
     django-nose==1.2
+    responses==0.5.1
     -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = django171_py27
 
 [testenv]
-commands=python manage.py test trello_webhooks
+commands=python manage.py test test_app trello_webhooks
 setenv =
     DJANGO_SETTINGS_MODULE=test_app.test_settings
     PYTHONPATH={toxinidir}

--- a/trello_webhooks/attachments.py
+++ b/trello_webhooks/attachments.py
@@ -1,0 +1,30 @@
+import mimetypes
+
+import requests
+
+
+def calculate_content_type(url):
+    """Attempts to work out the content type (mimetype) of a given URL.
+
+    First we rely on guessing the mimetype from the extension, to save use
+    a sync HTTP request. If that fails, we try a HEAD request to retrieve
+    the content type from the server without downloading the entire file.
+
+    NB: mimetype lookup by extension can be unreliable but for this use
+    case the level of reliability is better than firing a request every time.
+    """
+    content_type = mimetypes.guess_type(url)[0]
+    if not content_type:
+        return retrieve_content_type(url)
+    return content_type
+
+
+def retrieve_content_type(url):
+    """Calculate a URLs content-type by visiting it with a HEAD request."""
+    try:
+        response = requests.head(url)
+    except requests.RequestException:
+        return ''
+    else:
+        content_type = response.headers.get('content-type')
+        return content_type

--- a/trello_webhooks/management/commands/resolve_content_types.py
+++ b/trello_webhooks/management/commands/resolve_content_types.py
@@ -1,0 +1,20 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from trello_webhooks.models import CallbackEvent
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    help = "Resolves content types of existing events, if they have an attachment."
+
+    def handle(self, *args, **kwargs):
+        callback_events = CallbackEvent.objects.filter(event_type="addAttachmentToCard")
+        for callback_event in callback_events:
+            logger.info("Processing event: %s", callback_event)
+            callback_event.save()
+        logger.info("Finished.")

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,78 @@
+{
+    "action": {
+        "data": {
+            "attachment": {
+                "id": "57d6cd5a3a11e0c12d9bb389",
+                "name": "7477897782_18aaf3f3a9_k.jpg",
+                "previewUrl": "https://trello-attachments.s3.amazonaws.com/57d6cd18d1abe740904027ed/600x402/1d1958810b23410f4902b8eca980e209/7477897782_18aaf3f3a9_k.jpg",
+                "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/57d6cd18d1abe740904027ed/1200x803/da76ce6be5cfaee112b9361635265bc4/7477897782_18aaf3f3a9_k.jpg",
+                "url": "https://trello-attachments.s3.amazonaws.com/57d6cd18d1abe740904027ed/2048x1371/94116ea266ab99e539bb47355b3908a9/7477897782_18aaf3f3a9_k.jpg"
+            },
+            "board": {
+                "id": "57d6cc81abed37c4007e3f1b",
+                "name": "Hexfox - New Two",
+                "shortLink": "kChECKME"
+            },
+            "card": {
+                "id": "57d6cd18d1abe740904027ed",
+                "idShort": 1,
+                "name": "New card",
+                "shortLink": "p52qgjaG"
+            }
+        },
+        "date": "2016-09-12T15:44:29.609Z",
+        "id": "57d6cd5d3a11e0c12d9bb3b5",
+        "idMemberCreator": "4ea53819efb7a697ac1981ee",
+        "memberCreator": {
+            "avatarHash": "f9f544950aa205fc3f3204112511ded2",
+            "fullName": "Darian Moody",
+            "id": "4ea53819efb7a697ac1981ee",
+            "initials": "DJM",
+            "username": "djm_"
+        },
+        "type": "addAttachmentToCard"
+    },
+    "model": {
+        "closed": false,
+        "desc": "",
+        "descData": null,
+        "id": "57d6cc81abed37c4007e3f1b",
+        "idOrganization": "574e154ce71c92e7e5b3e716",
+        "labelNames": {
+            "black": "",
+            "blue": "",
+            "green": "",
+            "lime": "",
+            "orange": "",
+            "pink": "",
+            "purple": "",
+            "red": "",
+            "sky": "",
+            "yellow": ""
+        },
+        "name": "Hexfox - New Two",
+        "pinned": false,
+        "prefs": {
+            "background": "blue",
+            "backgroundBrightness": "dark",
+            "backgroundColor": "#0079BF",
+            "backgroundImage": null,
+            "backgroundImageScaled": null,
+            "backgroundTile": false,
+            "calendarFeedEnabled": false,
+            "canBeOrg": true,
+            "canBePrivate": true,
+            "canBePublic": true,
+            "canInvite": true,
+            "cardAging": "regular",
+            "cardCovers": true,
+            "comments": "members",
+            "invitations": "members",
+            "permissionLevel": "org",
+            "selfJoin": true,
+            "voting": "disabled"
+        },
+        "shortUrl": "https://trello.com/b/kChECKME",
+        "url": "https://trello.com/b/kChECKME/hexfox-new-two"
+    }
+}

--- a/trello_webhooks/tests/test_attachments.py
+++ b/trello_webhooks/tests/test_attachments.py
@@ -1,0 +1,44 @@
+from mock import patch
+
+import responses
+from requests.exceptions import HTTPError
+
+from django.test import TestCase
+from trello_webhooks import attachments
+
+
+@patch.object(attachments, 'retrieve_content_type')
+class CalculateContentTypeTests(TestCase):
+
+    def test_calculate_content_type_with_known_extension(
+            self, mocked_retrieve_content_type):
+        url = "https://www.example.com/example.jpg"
+        content_type = attachments.calculate_content_type(url)
+        self.assertEqual(content_type, "image/jpeg")
+        self.assertFalse(mocked_retrieve_content_type.called)
+
+    def test_calculate_content_type_with_missing_extension(
+            self, mocked_retrieve_content_type):
+        mocked_retrieve_content_type.return_value = "image/png"
+        url = "https://www.example.com/example"
+        content_type = attachments.calculate_content_type(url)
+        self.assertEqual(content_type, "image/png")
+        mocked_retrieve_content_type.assert_called_once_with(url)
+
+
+class RetrieveContentTypeTests(TestCase):
+
+    @responses.activate
+    def test_successful_retrieval(self):
+        url = "https://www.example.com/example.png"
+        responses.add(responses.HEAD, url, status=200, content_type='image/png')
+        content_type = attachments.retrieve_content_type(url)
+        self.assertEqual(content_type, 'image/png')
+
+    @responses.activate
+    def test_retrieval_raises_exception(self):
+        url = "https://www.example.com/example.png"
+        exception = HTTPError('Timeout or something')
+        responses.add(responses.HEAD, url, body=exception)
+        content_type = attachments.retrieve_content_type(url)
+        self.assertEqual(content_type, '')

--- a/trello_webhooks/tests/test_models.py
+++ b/trello_webhooks/tests/test_models.py
@@ -257,7 +257,12 @@ class WebhookModelTests(TestCase):
 class CallbackEventModelTest(TestCase):
 
     def test_default_properties(self):
-        pass
+        ce = CallbackEvent()
+        self.assertIsNone(ce.id)
+        self.assertIsNone(ce.webhook_id)
+        self.assertIsNone(ce.timestamp)
+        self.assertEqual(ce.event_type, '')
+        self.assertEqual(ce.event_payload, {})
 
     def test_save(self):
         pass

--- a/trello_webhooks/tests/test_views.py
+++ b/trello_webhooks/tests/test_views.py
@@ -9,7 +9,6 @@ from trello_webhooks.tests import get_sample_data
 
 
 class WebhookViewTests(TestCase):
-    pass
 
     def setUp(self):
         self.payload = {'auth_token': 'A', 'trello_model_id': '123'}


### PR DESCRIPTION
Hi all,

This is slightly different from a normal PR so I've chunked it:

## Pull Request

This changeset exists to add content-type specific HTML rendering to outbound messages. When attachments are uploaded to Trello, an `addAttachmentToCard` event is fired to any registered webhooks. This change means that when we receive an event, the code takes notice if it has an attachment and if it does we calculate the content-type (mimetype) of the attachment and store it in the `action.data.attachment.mimeType` path of the inbound JSON.

Then on outbound message render, we check for the presence of this content-type: if the content-type is undefined, we simply print the filename in rendered output; if the content-type is that of an image, we render an HTML image tag to show it inline in Hipchat; and if the content-type is any other unsupported mimetype, we again simple print the filename in the output.

There are no migrations as part of this PR.

## Of note, for the future

Not having the requirements and versions from the get go made that stage a bit of a guessing game - especially as jsonfield and django-jsonfield both exist, share the same API and are close in version numbers. If it's OK with you, I'll submit another PR after this to add the requirements once and for all.

I added the [responses](https://github.com/getsentry/responses) library for easily mocking out HTTP reqs made by the requests library. Adding dependencies is not something I take lightly and in real life would likely be done with regards to the maintainability of the project and what the teams consensus is on the package's usefulness. Here, for me, it made sense though.

## Extra Tickets

Given this is a "real life" kind of test, here are some things I would bring up/make new tickets for but didn't feel needed changing as part of this PR:

* This [unique_together constraint](https://github.com/yunojuno/django-test/blob/b4aacf65587c1ae728c4dfe39db79c4e8b1618fe/trello_webhooks/models.py#L74) on the Webhook model is currently doing nothing as it is defined at the class level and needs to be moved in to the inner `class Meta` options. A schema migration would then be required to add the new index to Postgres.

* [signals.get_supported_events](https://github.com/yunojuno/django-test/blob/b4aacf65587c1ae728c4dfe39db79c4e8b1618fe/test_app/signals.py#L15) is an unused function and can therefore likely be removed, I'm not sure if this is just because this is a test or not. If it was ever active it would have hindered scaling, as doing a file walk on every inbound request would be I/O expensive.

* There is a bug in the logger formatting in [test_app.signals](https://github.com/yunojuno/django-test/blob/b4aacf65587c1ae728c4dfe39db79c4e8b1618fe/test_app/signals.py#L40), the number of string formatting elements should equal that of the number of arguments.

----

Any questions, please don't hesitate to ask or confirm with me why I did something a certain way.

Thanks for the opportunity!

Cheers!
Darian