### PR TITLE
Video content rendering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dj-database-url==0.3.0
 django-jsonfield==0.9.13
 git+https://github.com/sarumont/py-trello.git@766c90dc1dacd2e3fcfc579079a6aab38be43aef
 psycopg2==2.5.4
+requests==2.13.0

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -2,17 +2,16 @@
 import json
 import logging
 
+import requests
+import trello
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.template.base import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.utils import timezone
-
 from jsonfield import JSONField
-import trello
 
-from trello_webhooks import settings
-from trello_webhooks import signals
+from trello_webhooks import settings, signals
 
 logger = logging.getLogger(__name__)
 
@@ -264,10 +263,24 @@ class CallbackEvent(models.Model):
         )
 
     def save(self, *args, **kwargs):
-        """Update timestamp"""
+        """Update timestamp and add attachment content type"""
         self.timestamp = timezone.now()
+
+        content_type = self.attachment_content_type
+        if content_type:
+            self.action_data['attachment']['content_type'] = content_type
+
         super(CallbackEvent, self).save(*args, **kwargs)
         return self
+
+    @property
+    def attachment_content_type(self):
+        data = self.action_data
+        if data:
+            attachment = data.get('attachment')
+            if attachment:
+                url = attachment['url']
+                return requests.head(url).headers.get('content-type', 'application/octet-stream')
 
     @property
     def action_data(self):

--- a/trello_webhooks/templates/trello_webhooks/addAttachmentToCard.html
+++ b/trello_webhooks/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,2 +1,3 @@
-<strong>{{action.memberCreator.initials}}</strong> added attachment "<strong><a href="{{action.data.attachment.url}}">{{action.data.attachment.name}}</a></strong>"
+{% load hipchat %}
+<strong>{{action.memberCreator.initials}}</strong> added attachment {{action.data.attachment.url|render_attachment}}
 {% include 'trello_webhooks/partials/card_link.html' %}

--- a/trello_webhooks/templatetags/hipchat.py
+++ b/trello_webhooks/templatetags/hipchat.py
@@ -1,0 +1,19 @@
+import re
+
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.filter(name='render_attachment')
+def render_attachment(attachment_data):
+    """render attachment with appropriate html"""
+    content_type = attachment_data.get('content_type', '')
+
+    if re.match('video/*', content_type):
+        attachment_string = '<video src="{url}" controls></video>'
+    else:
+        attachment_string = '<a href="{url}">{name}</a>'
+
+    return mark_safe(attachment_string.format(**attachment_data))

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,9 @@
+{
+  "action": {
+    "data": {
+      "attachment": {
+        "url": "https://trello-attachments.s3.amazonaws.com/58e64ada0460365186e7721b/58e78b5c69b2390da30e99e4/419d4dd7ce645db401b6874fb4cf7f3a/small.webm"
+      }
+    }
+  }
+}

--- a/trello_webhooks/tests/test_templatetags.py
+++ b/trello_webhooks/tests/test_templatetags.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
+from django.template import Context, Template
 from django.test import TestCase
 
 from trello_webhooks.settings import TRELLO_API_KEY
-from trello_webhooks.templatetags.trello_webhook_tags import (
-    trello_api_key,
-    trello_updates
-)
+from trello_webhooks.templatetags.trello_webhook_tags import (trello_api_key,
+                                                              trello_updates)
 
 
 class TemplateTagTests(TestCase):
@@ -28,3 +27,21 @@ class TemplateTagTests(TestCase):
             trello_updates(new, old),
             {'pos': (1, None)}
         )
+
+
+class TestHipchatTags(TestCase):
+    TEMPLATE = Template("{% load hipchat %} {{ attachment|render_attachment }}")
+
+    def test_render_attachment(self):
+        attachment = {'url': 'http://test',
+                      'name': 'test-name',
+                      'content_type': 'test'}
+        rendered = self.TEMPLATE.render(Context({'attachment': attachment}))
+
+        self.assertIn('test-name', rendered)
+
+        attachment = {'url': 'http://test',
+                      'name': 'test-name',
+                      'content_type': 'video/webm'}
+        rendered = self.TEMPLATE.render(Context({'attachment': attachment}))
+        self.assertIn('video', rendered)


### PR DESCRIPTION
Adds content-type specific rendering for addAttachmentToCard event to Hipchat.

If the attachment is a video it is rendered with video tag or just a simple text link otherwise.