### PR TITLE
Add attachment content-type handling and appropriate attachment rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage_reports/
 
 # Translations
 *.mo
@@ -53,3 +54,6 @@ coverage.xml
 docs/_build/
 
 test_app/static
+
+# Editor settings
+.idea/

--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,0 +1,3 @@
+{% load hipchat_tags %}
+<strong>{{action.memberCreator.initials}}</strong> added attachment "<strong>{{action.data.attachment|render_attachment}}</strong>"
+{% include 'trello_webhooks/partials/card_link.html' %}

--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,3 +1,4 @@
 {% load hipchat_tags %}
-<strong>{{action.memberCreator.initials}}</strong> added attachment "<strong>{{action.data.attachment|render_attachment}}</strong>"
+<strong>{{action.memberCreator.initials}}</strong> added attachment "
+<strong>{{action.data.attachment|render_attachment}}</strong>"
 {% include 'trello_webhooks/partials/card_link.html' %}

--- a/test_app/templatetags/__init__.py
+++ b/test_app/templatetags/__init__.py
@@ -1,0 +1,3 @@
+import hipchat_tags
+
+__all__ = ['hipchat_tags']

--- a/test_app/templatetags/hipchat_tags.py
+++ b/test_app/templatetags/hipchat_tags.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.filter
+def render_attachment(attachment_data):
+    """Render attachment to correct html.
+    If attachment data has an image type, template will be formatted with img tag.
+    Otherwise if will be formatted as a simple url"""
+    content_type = attachment_data.get('content_type', '')
+    attachment_is_image = content_type.split('/').lower() == 'image'
+
+    formatted_string = '<a href="{{url}}"><img src={{url}}></a>' if attachment_is_image \
+        else '<a href="{{url}}">{{name}}</a>'
+
+    return mark_safe(formatted_string.format(**attachment_data))

--- a/test_app/templatetags/hipchat_tags.py
+++ b/test_app/templatetags/hipchat_tags.py
@@ -7,9 +7,11 @@ register = template.Library()
 
 @register.filter
 def render_attachment(attachment_data):
-    """Render attachment to correct html.
+    """
+    Render attachment to correct html.
     If attachment data has an image type, template will be formatted with img tag.
-    Otherwise if will be formatted as a simple url"""
+    Otherwise if will be formatted as a simple url
+    """
     content_type = attachment_data.get('content_type', '')
     attachment_is_image = content_type.split('/')[0].lower() == 'image'
 

--- a/test_app/templatetags/hipchat_tags.py
+++ b/test_app/templatetags/hipchat_tags.py
@@ -11,9 +11,9 @@ def render_attachment(attachment_data):
     If attachment data has an image type, template will be formatted with img tag.
     Otherwise if will be formatted as a simple url"""
     content_type = attachment_data.get('content_type', '')
-    attachment_is_image = content_type.split('/').lower() == 'image'
+    attachment_is_image = content_type.split('/')[0].lower() == 'image'
 
-    formatted_string = '<a href="{{url}}"><img src={{url}}></a>' if attachment_is_image \
-        else '<a href="{{url}}">{{name}}</a>'
+    formatted_string = '<a href="{url}"><img src={url}></a>' if attachment_is_image \
+        else '<a href="{url}">{name}</a>'
 
     return mark_safe(formatted_string.format(**attachment_data))

--- a/test_app/test_settings.py
+++ b/test_app/test_settings.py
@@ -11,7 +11,7 @@ DATABASES = {
 }
 
 # the django apps aren't required for the tests,
-INSTALLED_APPS = ('trello_webhooks',)
+INSTALLED_APPS = ('trello_webhooks', 'test_app',)
 
 try:
     import django_nose  # noqa

--- a/test_app/tests/test_templatetags.py
+++ b/test_app/tests/test_templatetags.py
@@ -7,7 +7,7 @@ class TestTemplateTags(TestCase):
 
     template = Template("{% load hipchat_tags %} {{ attachment|render_attachment }}")
 
-    def test_render_image_attachment(self):
+    def test_image_content_type_is_rendered_in_img_tag(self):
         image_attachment = {
             'url': 'http://test.com',
             'name': 'test-image',
@@ -17,7 +17,7 @@ class TestTemplateTags(TestCase):
         self.assertIn('img', rendered_template)
         self.assertIn(image_attachment['url'], rendered_template)
 
-    def test_render_not_image_attachment(self):
+    def test_image_content_type_is_not_rendered_in_img_tag(self):
         not_image_attachment = {
             'url': 'http://test.com',
             'name': 'some-document',

--- a/test_app/tests/test_templatetags.py
+++ b/test_app/tests/test_templatetags.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from django.template import Context, Template
+from django.test import TestCase
+
+
+class TestTemplateTags(TestCase):
+
+    template = Template("{% load hipchat_tags %} {{ attachment|render_attachment }}")
+
+    def test_render_image_attachment(self):
+        image_attachment = {
+            'url': 'http://test.com',
+            'name': 'test-image',
+            'content_type': 'image/png'
+        }
+        rendered_template = self.template.render(Context({'attachment': image_attachment}))
+        self.assertIn('img', rendered_template)
+        self.assertIn(image_attachment['url'], rendered_template)
+
+    def test_render_not_image_attachment(self):
+        not_image_attachment = {
+            'url': 'http://test.com',
+            'name': 'some-document',
+            'content_type': 'application/pdf'
+        }
+        rendered_template = self.template.render(Context({'attachment': not_image_attachment}))
+        self.assertNotIn('img', rendered_template)
+        self.assertIn(not_image_attachment['url'], rendered_template)
+        self.assertIn(not_image_attachment['name'], rendered_template)

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -280,19 +280,22 @@ class CallbackEvent(models.Model):
             return None
         else:
             try:
-                request = requests.head(self.attachment.get('url'))
+                attachment_url = self.attachment.get('url')
+                request = requests.head(attachment_url)
                 return request.headers.get('Content-Type')
             except requests.exceptions.ConnectionError:
                 logger.warning(
-                    u"Connection error on attachment url='{url}' raised".format(**self.attachment)
+                    u"Connection error on attachment url='{}' raised".format(attachment_url)
                 )
             except requests.exceptions.MissingSchema:
                 logger.warning(
-                    u"Incorrect attachment url='{url}' was received".format(**self.attachment)
+                    u"Incorrect attachment url='{}' was received".format(attachment_url)
                 )
             except Exception as ex:
                 logger.warning(
-                    u"Unexpected error occurred. Exception info: {}".format(ex)
+                    u"Unexpected error occurred. "
+                    u"Exception info: {}. "
+                    u"Attachment url='{}'".format(ex, attachment_url)
                 )
 
     @property

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -295,7 +295,6 @@ class CallbackEvent(models.Model):
                     u"Unexpected error occurred. Exception info: {}".format(ex)
                 )
 
-
     @property
     def action_data(self):
         """Returns the 'data' node from the payload."""

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -276,19 +276,25 @@ class CallbackEvent(models.Model):
     def get_attachment_content_type(self):
         """Return attachment type from attached data (if attachment and attachment url exist)
         or None(in exception case or attachment doesn't exist)"""
-        if self.attachment is not None and self.attachment.get('url'):
+        if self.attachment is None or not self.attachment.get('url'):
+            return None
+        else:
             try:
                 request = requests.head(self.attachment.get('url'))
                 return request.headers.get('Content-Type')
             except requests.exceptions.ConnectionError:
                 logger.warning(
-                    u"Connection error on attachment url raised"
+                    u"Connection error on attachment url='{url}' raised".format(**self.attachment)
                 )
-            except requests.exceptions.MissingSchema as ex:
+            except requests.exceptions.MissingSchema:
                 logger.warning(
-                    u"Incorrect attachment url was received"
+                    u"Incorrect attachment url='{url}' was received".format(**self.attachment)
                 )
-            return None
+            except Exception as ex:
+                logger.warning(
+                    u"Unexpected error occurred. Exception arguments: {}".format(ex)
+                )
+
 
     @property
     def action_data(self):

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -9,6 +9,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 
 from jsonfield import JSONField
+import requests
 import trello
 
 from trello_webhooks import settings
@@ -264,10 +265,26 @@ class CallbackEvent(models.Model):
         )
 
     def save(self, *args, **kwargs):
-        """Update timestamp"""
+        """Update timestamp and attachment content type"""
         self.timestamp = timezone.now()
+        content_type = self.get_attachment_content_type()
+        if content_type:
+            self.attachment['content_type'] = content_type
         super(CallbackEvent, self).save(*args, **kwargs)
         return self
+
+    def get_attachment_content_type(self):
+        """Return attachment type from attached data (if attachment and attachment url exist)
+        or None(in exception case or attachment doesn't exist)"""
+        if self.attachment is not None and self.attachment.get('url'):
+            try:
+                request = requests.head(self.attachment.get('url'))
+                return request.get('Content-Type')
+            except requests.exceptions.ConnectionError:
+                logger.warning(
+                    u"Connection error on attachment url raised"
+                )
+                return None
 
     @property
     def action_data(self):
@@ -318,6 +335,11 @@ class CallbackEvent(models.Model):
     def template(self):
         """Return full path to render template, based on event_type."""
         return 'trello_webhooks/%s.html' % self.event_type
+
+    @property
+    def attachment(self):
+        """Return 'attachment' JSON from event_payload if it exist."""
+        return self.action_data.get('attachment') if self.action_data else None
 
     def render(self):
         """Render the event using an HTML template.

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -279,12 +279,16 @@ class CallbackEvent(models.Model):
         if self.attachment is not None and self.attachment.get('url'):
             try:
                 request = requests.head(self.attachment.get('url'))
-                return request.get('Content-Type')
+                return request.headers.get('Content-Type')
             except requests.exceptions.ConnectionError:
                 logger.warning(
                     u"Connection error on attachment url raised"
                 )
-                return None
+            except requests.exceptions.MissingSchema as ex:
+                logger.warning(
+                    u"Incorrect attachment url was received"
+                )
+            return None
 
     @property
     def action_data(self):

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -292,7 +292,7 @@ class CallbackEvent(models.Model):
                 )
             except Exception as ex:
                 logger.warning(
-                    u"Unexpected error occurred. Exception arguments: {}".format(ex)
+                    u"Unexpected error occurred. Exception info: {}".format(ex)
                 )
 
 

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,87 @@
+{
+    "action": {
+        "id": "5476fc0999be2643698ded16",
+        "idMemberCreator": "4f55dc2f8e0358c24d194be0",
+        "data": {
+            "listAfter": {
+                "name": "Second list",
+                "id": "5476fc06d998c88c890b901d"
+            },
+            "listBefore": {
+                "name": "To Do",
+                "id": "5476fb3271e6d2370b31e986"
+            },
+            "board": {
+                "shortLink": "TAAnwdP9",
+                "name": "Django Trello Webhooks Test Board",
+                "id": "5476fab52086e26047fa328c"
+            },
+            "card": {
+                "shortLink": "4K7LwAKx",
+                "idShort": 1,
+                "name": "Test card",
+                "id": "5476fb7437746ac807afe2a5",
+                "idList": "5476fc06d998c88c890b901d"
+            },
+            "old": {
+                "idList": "5476fb3271e6d2370b31e986"
+            },
+            "attachment": {
+                "url": "http://test_url.com/some_attachment",
+                "name": "some_attachment"
+            }
+        },
+        "type": "addAttachmentToCard",
+        "date": "2014-11-27T10:25:13.238Z",
+        "memberCreator": {
+            "id": "4f55dc2f8e0358c24d194be0",
+            "avatarHash": "852f1ba717618e2d0ba0c0a8de5eaad4",
+            "fullName": "Hugo Rodger-Brown",
+            "initials": "HRB",
+            "username": "hrb"
+        }
+    },
+    "model": {
+        "id": "5476fab52086e26047fa328c",
+        "name": "Django Trello Webhooks Test Board",
+        "desc": "",
+        "descData": null,
+        "closed": false,
+        "idOrganization": null,
+        "pinned": false,
+        "url": "https://trello.com/b/TAAnwdP9/django-trello-webhooks-test-board",
+        "shortUrl": "https://trello.com/b/TAAnwdP9",
+        "prefs": {
+            "permissionLevel": "public",
+            "voting": "disabled",
+            "comments": "members",
+            "invitations": "members",
+            "selfJoin": false,
+            "cardCovers": true,
+            "cardAging": "regular",
+            "calendarFeedEnabled": false,
+            "background": "blue",
+            "backgroundColor": "#0079BF",
+            "backgroundImage": null,
+            "backgroundImageScaled": null,
+            "backgroundTile": false,
+            "backgroundBrightness": "unknown",
+            "canBePublic": true,
+            "canBeOrg": true,
+            "canBePrivate": true,
+            "canInvite": true
+        },
+        "labelNames": {
+            "green": "",
+            "yellow": "",
+            "orange": "",
+            "red": "",
+            "purple": "",
+            "blue": "",
+            "pink": "",
+            "sky": "",
+            "lime": "",
+            "black": ""
+        }
+    }
+}


### PR DESCRIPTION
Implement content-type specific rendering of the HipChat message for the addAttachmentToCard event.
If the attachment content-type is an image it is render using <img> tag, otherwise it is render as url.