### PR TITLE
add image content-type rendering of the HipChat message

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
-# Django==1.7.1
+Django==1.7.1
 dj-database-url==0.3.0
 django-jsonfield==0.9.13
 git+https://github.com/sarumont/py-trello.git@766c90dc1dacd2e3fcfc579079a6aab38be43aef
 psycopg2==2.5.4
+requests==2.18.4
+mock==2.0.0
+ddt==1.1.2
+requests-mock==1.4.0

--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,0 +1,4 @@
+{%  load card_attachment_text %}
+<strong>{{action.memberCreator.initials}}</strong> added attachment "<strong>
+    <a href="{{action.data.attachment.url}}">{{action.data| card_attachment_text }}</a>
+</strong>"

--- a/test_app/templatetags/card_attachment_text.py
+++ b/test_app/templatetags/card_attachment_text.py
@@ -1,0 +1,31 @@
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+SUPPORTED_CONTENT_TYPES = {
+    'images': {
+        'content_types': [
+            'image/gif',
+            'image/png',
+            'image/jpeg',
+            'image/bmp',
+            'image/webp',
+        ],
+        'template': '<img src="%s">',
+    },
+}
+
+
+@register.filter
+def card_attachment_text(data):
+    attachment = data.get('attachment', {})
+    result = '%s' % (attachment.get('name'),)
+
+    content_type = attachment.get('content_type')
+
+    for supported_type, item in SUPPORTED_CONTENT_TYPES.iteritems():
+        if content_type in item['content_types']:
+            result = item['template'] % (attachment.get('previewUrl'),)
+
+    return mark_safe(result)

--- a/test_app/tests/test_card_attachment_text.py
+++ b/test_app/tests/test_card_attachment_text.py
@@ -1,0 +1,50 @@
+from ddt import ddt, data
+from django.test import TestCase
+
+from test_app.templatetags.card_attachment_text import card_attachment_text
+
+
+@ddt
+class CardAttachmentTextTest(TestCase):
+    @data(
+        'image/gif',
+        'image/png',
+        'image/jpeg',
+        'image/bmp',
+        'image/webp',
+    )
+    def test_supported_image_content_type(self, content_type):
+        data = {
+            'attachment': {
+                'name': 'file.name',
+                'content_type': content_type,
+                'previewUrl': 'previewUrl'
+            }
+        }
+
+        expected_result = u'<img src="previewUrl">'
+
+        result = card_attachment_text(data)
+
+        self.assertEqual(expected_result, result)
+
+    @data(
+        '',
+        'my_awesome_type',
+        'image/tiff',
+        'text/plain',
+    )
+    def test_unsopported_content_type(self, content_type):
+        data = {
+            'attachment': {
+                'name': 'file.name',
+                'content_type': content_type,
+                'previewUrl': 'previewUrl'
+            }
+        }
+
+        expected_result = 'file.name'
+
+        result = card_attachment_text(data)
+
+        self.assertEqual(expected_result, result)

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,119 @@
+{
+  "model": {
+    "id": "5ab25ccc40ae78d7ebbf25c2",
+    "name": "test",
+    "desc": "",
+    "descData": null,
+    "closed": false,
+    "idOrganization": "5971c7935a7ba802c0c9a76e",
+    "pinned": false,
+    "url": "https://trello.com/b/C26Hs9RV/dsad",
+    "shortUrl": "https://trello.com/b/C26Hs9RV",
+    "prefs": {
+      "permissionLevel": "org",
+      "voting": "disabled",
+      "comments": "members",
+      "invitations": "members",
+      "selfJoin": true,
+      "cardCovers": true,
+      "cardAging": "regular",
+      "calendarFeedEnabled": false,
+      "background": "5aa7c74a3634f3b5e1c3d66a",
+      "backgroundImage": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2560x1707/31e2b1391c87caa9f06c1f6f30cd0a17/photo-1520858362407-812e1188b1eb",
+      "backgroundImageScaled": null,
+      "backgroundTile": false,
+      "backgroundBrightness": "light",
+      "backgroundBottomColor": "#92c0d0",
+      "backgroundTopColor": "#255b6d",
+      "canBePublic": true,
+      "canBeOrg": true,
+      "canBePrivate": true,
+      "canInvite": true
+    },
+    "labelNames": {
+      "green": "",
+      "yellow": "",
+      "orange": "",
+      "red": "",
+      "purple": "",
+      "blue": "",
+      "sky": "",
+      "lime": "",
+      "pink": "",
+      "black": ""
+    }
+  },
+  "action": {
+    "id": "5ab25f8a173c81ecb665810a",
+    "idMemberCreator": "5364d931fa4ccee60c20c1fc",
+    "data": {
+      "board": {
+        "shortLink": "C26Hs9RV",
+        "name": "test",
+        "id": "5ab25ccc40ae78d7ebbf25c2"
+      },
+      "list": {
+        "name": "test",
+        "id": "5ab25cd61483ac90f766568e"
+      },
+      "card": {
+        "shortLink": "yBluCMhF",
+        "idShort": 3,
+        "name": "test",
+        "id": "5ab25ec23da27bec4bc2c394"
+      },
+      "attachment": {
+        "url": "https://trello-attachments.s3.amazonaws.com/5ab25ccc40ae78d7ebbf25c2/5ab25ec23da27bec4bc2c394/386eb754fd7272781106a9e5ca9b6ece/test.jpg",
+        "name": "test.jpg",
+        "id": "5ab25f8a173c81ecb6658105",
+        "edgeColor": "#fcfcfc",
+        "previewUrl": "https://trello-attachments.s3.amazonaws.com/5ab25ccc40ae78d7ebbf25c2/5ab25ec23da27bec4bc2c394/386eb754fd7272781106a9e5ca9b6ece/test.jpg",
+        "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/5ab25ccc40ae78d7ebbf25c2/5ab25ec23da27bec4bc2c394/386eb754fd7272781106a9e5ca9b6ece/test.jpg"
+      }
+    },
+    "type": "addAttachmentToCard",
+    "date": "2018-03-21T13:35:06.814Z",
+    "display": {
+      "translationKey": "action_add_attachment_to_card",
+      "entities": {
+        "attachment": {
+          "type": "attachment",
+          "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/5ab25ccc40ae78d7ebbf25c2/5ab25ec23da27bec4bc2c394/386eb754fd7272781106a9e5ca9b6ece/test.jpg",
+          "previewUrl": "https://trello-attachments.s3.amazonaws.com/5ab25ccc40ae78d7ebbf25c2/5ab25ec23da27bec4bc2c394/386eb754fd7272781106a9e5ca9b6ece/test.jpg",
+          "edgeColor": "#fcfcfc",
+          "id": "5ab25f8a173c81ecb6658105",
+          "link": true,
+          "text": "test.jpg",
+          "url": "https://trello-attachments.s3.amazonaws.com/5ab25ccc40ae78d7ebbf25c2/5ab25ec23da27bec4bc2c394/386eb754fd7272781106a9e5ca9b6ece/test.jpg"
+        },
+        "attachmentPreview": {
+          "type": "attachmentPreview",
+          "originalUrl": "https://trello-attachments.s3.amazonaws.com/5ab25ccc40ae78d7ebbf25c2/5ab25ec23da27bec4bc2c394/386eb754fd7272781106a9e5ca9b6ece/test.jpg",
+          "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/5ab25ccc40ae78d7ebbf25c2/5ab25ec23da27bec4bc2c394/386eb754fd7272781106a9e5ca9b6ece/test.jpg",
+          "previewUrl": "https://trello-attachments.s3.amazonaws.com/5ab25ccc40ae78d7ebbf25c2/5ab25ec23da27bec4bc2c394/386eb754fd7272781106a9e5ca9b6ece/test.jpg",
+          "edgeColor": "#fcfcfc",
+          "id": "5ab25f8a173c81ecb6658105"
+        },
+        "card": {
+          "type": "card",
+          "id": "5ab25ec23da27bec4bc2c394",
+          "shortLink": "yBluCMhF",
+          "text": "hello"
+        },
+        "memberCreator": {
+          "type": "member",
+          "id": "5364d931fa4ccee60c20c1fc",
+          "username": "testuser",
+          "text": "Test User"
+        }
+      }
+    },
+    "memberCreator": {
+      "id": "5364d931fa4ccee60c20c1fc",
+      "avatarHash": "",
+      "fullName": "Test User",
+      "initials": "TU",
+      "username": "testuser"
+    }
+  }
+}


### PR DESCRIPTION
Implemented functionality which allows set different templates for different content-types. In this pull request added functionality only for images, but it can be easily extended. 

Steps to add new content type:
1) Add new key to `SUPPORTED_CONTENT_TYPES` variable (e.g. video)
2) Add two new keys to key from step one - `content_types` and `template`. The `content_types` shows which content-types should be processed,
the `template` is template which will be rendered for this type.