### PR TITLE
Feat/add callbackevent attachment content type

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.8
 dj-database-url==0.3.0
-django-jsonfield==0.9.13
-git+https://github.com/sarumont/py-trello.git@766c90dc1dacd2e3fcfc579079a6aab38be43aef
-psycopg2==2.5.4
+django-jsonfield==1.0
+py-trello==0.10
+psycopg2==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.7.1
+Django==1.8
 dj-database-url==0.3.0
 django-jsonfield==0.9.13
 git+https://github.com/sarumont/py-trello.git@766c90dc1dacd2e3fcfc579079a6aab38be43aef

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Django==1.7.1
+Django==1.7.1
 dj-database-url==0.3.0
 django-jsonfield==0.9.13
 git+https://github.com/sarumont/py-trello.git@766c90dc1dacd2e3fcfc579079a6aab38be43aef

--- a/test_app/__init__.py
+++ b/test_app/__init__.py
@@ -1,1 +1,4 @@
 from test_app import signals  # noqa
+from test_app import hipchat  # noqa
+
+__all__ = ["signals", "hipchat"]

--- a/test_app/hipchat.py
+++ b/test_app/hipchat.py
@@ -7,12 +7,12 @@ HIPCHAT_API_URL = 'https://api.hipchat.com/v1/rooms/message'
 
 
 def send_to_hipchat(
-    message,
-    token=settings.HIPCHAT_API_TOKEN,
-    room=settings.HIPCHAT_ROOM_ID,
-    sender="Trello",
-    color="yellow",
-    notify=False):
+        message,
+        token=settings.HIPCHAT_API_TOKEN,
+        room=settings.HIPCHAT_ROOM_ID,
+        sender="Trello",
+        color="yellow",
+        notify=False):
     """
     Send a message to HipChat.
 

--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,0 +1,3 @@
+{% include trello_callbackevent_tags %}<strong>
+{{action.memberCreator.initials}}</strong> added attachment "<strong><a href="{{action.data.attachment.url}}">{{action.data.attachment | attachment_name_or_inline_image}}</a></strong>"
+{% include 'trello_webhooks/partials/card_link.html' %}

--- a/test_app/templatetags/__init__.py
+++ b/test_app/templatetags/__init__.py
@@ -1,0 +1,1 @@
+# test_app.templatetags package

--- a/test_app/templatetags/trello_callbackevent_tags.py
+++ b/test_app/templatetags/trello_callbackevent_tags.py
@@ -1,0 +1,23 @@
+# template tags used in HipChat event template
+from django import template
+from django.utils.safestring import mark_safe
+
+
+register = template.Library()
+
+
+@register.filter
+def attachment_name_or_inline_image(attachment):
+    """
+    Returns attachment name text or safe inline 'img' node with attachment url
+    as source.
+    """
+    name = attachment['name']
+    content_type = attachment.get('content_type', '')
+
+    # render safe html 'img' tag only if content_type is image
+    if content_type.startswith('image/'):
+        tmpl = u'<img src="%s" alt="%s">' % (attachment['url'], name)
+        return mark_safe(tmpl)
+
+    return name

--- a/test_app/tests/test_hipchat.py
+++ b/test_app/tests/test_hipchat.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+import mock
+
+from django.test import TestCase
+
+from test_app import hipchat
+
+
+class HipChatTests(TestCase):
+
+    @mock.patch("requests.post")
+    def test_hipchat(self, mock_post):
+        mock_post.return_value = mock.MagicMock(status_code=200)
+        hipchat.send_to_hipchat("testing")
+        self.assertEqual(mock_post.call_count, 1)

--- a/test_app/tests/test_signals.py
+++ b/test_app/tests/test_signals.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+import mock
+
+from django.test import TestCase
+
+from test_app.signals import (
+    get_supported_events,
+)
+
+
+class SignalTest(TestCase):
+
+    def test_get_supported_events(self):
+        good = get_supported_events()
+        self.assertTrue("updateComment" in good)
+        self.assertTrue("addAttachmentToCard" in good)

--- a/test_app/tests/test_templatetags.py
+++ b/test_app/tests/test_templatetags.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase
+
+from test_app.templatetags.trello_callbackevent_tags import (
+    attachment_name_or_inline_image,
+)
+
+
+class TemplateTagTests(TestCase):
+
+    def test_attachment_name_or_inline_image(self):
+        attachment_name = 'attachment_name'
+        attachment_url = 'attachment_url'
+        safe_image_tag = '<img src="%s" alt="%s">' % (
+            attachment_url, attachment_name
+        )
+        # good data: with image
+        good = {
+            'name': attachment_name,
+            'url': attachment_url,
+            'content_type': 'image/png'
+        }
+        self.assertEqual(
+            attachment_name_or_inline_image(good),
+            safe_image_tag
+        )
+
+        # bad data missing content_type: with name
+        bad_missing_content_type = {
+            'name': attachment_name,
+            'url': attachment_url
+        }
+        self.assertEqual(
+            attachment_name_or_inline_image(bad_missing_content_type),
+            attachment_name
+        )
+
+        # bad data non-image content_type: with name
+        bad_non_image_content_type = {
+            'name': attachment_name,
+            'url': attachment_url,
+            'content_type': 'text/plain'
+        }
+        self.assertEqual(
+            attachment_name_or_inline_image(bad_non_image_content_type),
+            attachment_name
+        )

--- a/trello_webhooks/management/commands/update_callbackevent_content_type.py
+++ b/trello_webhooks/management/commands/update_callbackevent_content_type.py
@@ -1,0 +1,64 @@
+# # -*- coding: utf-8 -*-
+# update content_type with all existing CallbackEvent in database
+from optparse import make_option
+import logging
+import time
+
+from django.core.management.base import BaseCommand
+
+from trello_webhooks.models import CallbackEvent
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = u"Update 'content_type' with existing CallbackEvent in database."
+    option_list = BaseCommand.option_list + (
+        make_option(
+            "-w",
+            "--wait",
+            dest="wait",
+            default=200,
+            help=u"Run command in wait mode (default 200), pause betweek calls"
+        ),
+    )
+
+    def handle(self, *args, **options):
+        """Update 'content_type' with existing CallbackEvent in database.
+
+        Since 'content_type' is determined by issuing a HEAD requests call to
+        attachment's url, this could be an expensive operation if we go
+        through all database records.
+
+        You can set the 'wait' parameter with '--wait' flag, with the given
+        'wait' time (in ms), it will pause between each HEAD requests call.
+
+        Updated records will not be touched again, so it is safe to run this
+        command multiple times.
+        """
+
+        logger.info(
+            u"Querying CallbackEvent with attachment but missing content_type"
+        )
+        ces = CallbackEvent.objects.filter(
+            event_payload__contains='"attachment":'
+        ).exclude(
+            event_payload__contains='"content_type":'
+        )
+
+        wait = options["wait"]
+        success_count = 0
+
+        # Using iterator here to avoid unnecessary result caching
+        for ce in ces.iterator():
+            # this will call update_callbackevent_content_type
+            ce.save(update_fields=["event_payload"])
+            success_count += 1
+            logger.info(
+                u"Updated %s successfully with '%s'",
+                repr(ce), ce.attachment.get("content_type")
+            )
+            # if 'wait' time (ms) is set, let's take a pause
+            wait and time.sleep(wait)
+
+        logger.info(u"Total %d records updated", success_count)

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -225,7 +225,7 @@ class Webhook(models.Model):
         event = CallbackEvent(
             webhook=self,
             event_type=action,
-            event_payload=body_text
+            event_payload=payload
         ).save()
         self.touch()
         signals.callback_received.send(sender=self.__class__, event=event)

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,68 @@
+{
+    "action": {
+        "id": "55411859be21b8ad7dcd4c78",
+        "idMemberCreator": "54e20f22ca5e45bc555c1cdb",
+        "data": {
+            "board": {
+                "shortLink": "nC8QJJoZ",
+                "name": "Trello Development",
+                "id": "4d5ea62fd76aa1136000000c"
+            },
+            "card": {
+                "shortLink": "NIRpzVDM",
+                "idShort": 1211,
+                "name": "What can you expect from this board?",
+                "id": "4f7dcc310113192a307f347d"
+            },
+            "attachment": {
+                "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/4f7dcc310113192a307f347d/1200x1176/728412168dacbfff02e9414d84a0356f/trello-logo.png",
+                "previewUrl": "https://trello-attachments.s3.amazonaws.com/4f7dcc310113192a307f347d/600x588/09dcbeb01f2de5d29a513c6e3aad3649/trello-logo.png",
+                "url": "https://trello-attachments.s3.amazonaws.com/4f7dcc310113192a307f347d/1294x1268/219cc6eb9c9b7b2ef8b1251c90a4184a/trello-logo.png",
+                "name": "trello-logo.png",
+                "id": "55411857be21b8ad7dcd4c70"
+            }
+        },
+        "type": "addAttachmentToCard",
+        "date": "2015-04-29T17:43:53.614Z",
+        "memberCreator": {
+            "id": "54e20f22ca5e45bc555c1cdb",
+            "avatarHash": "448c93683331562616e24a04b09d41fa",
+            "fullName": "Michelle Bearheart",
+            "initials": "MB",
+            "username": "michellebearheart"
+        },
+        "display": {
+            "translationKey": "action_add_attachment_to_card",
+            "entities": {
+                "attachment": {
+                    "type": "attachment",
+                    "id": "55411857be21b8ad7dcd4c70",
+                    "previewUrl": "https://trello-attachments.s3.amazonaws.com/4f7dcc310113192a307f347d/600x588/09dcbeb01f2de5d29a513c6e3aad3649/trello-logo.png",
+                    "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/4f7dcc310113192a307f347d/1200x1176/728412168dacbfff02e9414d84a0356f/trello-logo.png",
+                    "link": true,
+                    "text": "trello-logo.png",
+                    "url": "https://trello-attachments.s3.amazonaws.com/4f7dcc310113192a307f347d/1294x1268/219cc6eb9c9b7b2ef8b1251c90a4184a/trello-logo.png"
+                },
+                "attachmentPreview": {
+                    "type": "attachmentPreview",
+                    "originalUrl": "https://trello-attachments.s3.amazonaws.com/4f7dcc310113192a307f347d/1294x1268/219cc6eb9c9b7b2ef8b1251c90a4184a/trello-logo.png",
+                    "id": "55411857be21b8ad7dcd4c70",
+                    "previewUrl": "https://trello-attachments.s3.amazonaws.com/4f7dcc310113192a307f347d/600x588/09dcbeb01f2de5d29a513c6e3aad3649/trello-logo.png",
+                    "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/4f7dcc310113192a307f347d/1200x1176/728412168dacbfff02e9414d84a0356f/trello-logo.png"
+                },
+                "card": {
+                    "type": "card",
+                    "id": "4f7dcc310113192a307f347d",
+                    "shortLink": "NIRpzVDM",
+                    "text": "What can you expect from this board?"
+                },
+                "memberCreator": {
+                    "type": "member",
+                    "id": "54e20f22ca5e45bc555c1cdb",
+                    "username": "michellebearheart",
+                    "text": "Michelle Bearheart"
+                }
+            }
+        }
+    }
+}

--- a/trello_webhooks/tests/test_models.py
+++ b/trello_webhooks/tests/test_models.py
@@ -264,7 +264,7 @@ class CallbackEventModelTest(TestCase):
     def test_update_attachment_content_type_with_image(self, mock_head):
         mock_head.return_value = mock.MagicMock(status_code=200, headers={"Content-Type": "image/png"})  # noqa
         ce = CallbackEvent()
-        ce.event_payload = get_sample_data('addAttachmentToCard', 'text')
+        ce.event_payload = get_sample_data('addAttachmentToCard', 'json')
         self.assertIsNone(ce.attachment.get('content_type'))
         ce.update_attachment_content_type()
         self.assertEqual(ce.attachment.get('content_type'), 'image/png')
@@ -274,7 +274,7 @@ class CallbackEventModelTest(TestCase):
     def test_update_attachment_content_type_not_image(self, mock_head):
         mock_head.return_value = mock.MagicMock(status_code=200, headers={"Content-Type": "text/plain"})  # noqa
         ce = CallbackEvent()
-        ce.event_payload = get_sample_data('addAttachmentToCard', 'text')
+        ce.event_payload = get_sample_data('addAttachmentToCard', 'json')
         self.assertIsNone(ce.attachment.get('content_type'))
         ce.update_attachment_content_type()
         self.assertEqual(ce.attachment.get('content_type'), 'text/plain')
@@ -284,7 +284,7 @@ class CallbackEventModelTest(TestCase):
     def test_update_attachment_content_type_exception(self, mock_head):
         mock_head.side_effect = requests.exceptions.RequestException("Mock exception")  # noqa
         ce = CallbackEvent()
-        ce.event_payload = get_sample_data('addAttachmentToCard', 'text')
+        ce.event_payload = get_sample_data('addAttachmentToCard', 'json')
         self.assertIsNone(ce.attachment.get('content_type'))
         # attachment is image but requests failed, method call without effect
         ce.update_attachment_content_type()
@@ -297,59 +297,59 @@ class CallbackEventModelTest(TestCase):
     def test_action_data(self):
         ce = CallbackEvent()
         self.assertEqual(ce.action_data, None)
-        ce.event_payload = get_sample_data('createCard', 'text')
+        ce.event_payload = get_sample_data('createCard', 'json')
         self.assertEqual(ce.action_data, ce.event_payload['action']['data'])
 
     def test_attachment(self):
         ce = CallbackEvent()
         self.assertEqual(ce.attachment, None)
-        ce.event_payload = get_sample_data('addAttachmentToCard', 'text')
+        ce.event_payload = get_sample_data('addAttachmentToCard', 'json')
         self.assertEqual(ce.attachment, ce.event_payload['action']['data']['attachment'])  # noqa
 
     def test_member(self):
         ce = CallbackEvent()
         self.assertEqual(ce.action_data, None)
-        ce.event_payload = get_sample_data('createCard', 'text')
+        ce.event_payload = get_sample_data('createCard', 'json')
         self.assertEqual(ce.member, ce.event_payload['action']['memberCreator'])
 
     def test_board(self):
         ce = CallbackEvent()
         self.assertEqual(ce.board, None)
-        ce.event_payload = get_sample_data('createCard', 'text')
+        ce.event_payload = get_sample_data('createCard', 'json')
         self.assertEqual(ce.board, ce.event_payload['action']['data']['board'])
 
     def test_list(self):
         ce = CallbackEvent()
         self.assertEqual(ce.list, None)
-        ce.event_payload = get_sample_data('createCard', 'text')
+        ce.event_payload = get_sample_data('createCard', 'json')
         self.assertEqual(ce.list, ce.event_payload['action']['data']['list'])
 
     def test_card(self):
         ce = CallbackEvent()
         self.assertEqual(ce.card, None)
-        ce.event_payload = get_sample_data('createCard', 'text')
+        ce.event_payload = get_sample_data('createCard', 'json')
         self.assertEqual(ce.card, ce.event_payload['action']['data']['card'])
 
     def test_member_name(self):
         ce = CallbackEvent()
         self.assertEqual(ce.member_name, None)
-        ce.event_payload = get_sample_data('createCard', 'text')
+        ce.event_payload = get_sample_data('createCard', 'json')
         self.assertEqual(ce.member_name, ce.event_payload['action']['memberCreator']['fullName'])  # noqa
 
     def test_board_name(self):
         ce = CallbackEvent()
         self.assertEqual(ce.board_name, None)
-        ce.event_payload = get_sample_data('createCard', 'text')
+        ce.event_payload = get_sample_data('createCard', 'json')
         self.assertEqual(ce.board_name, ce.event_payload['action']['data']['board']['name'])  # noqa
 
     def test_list_name(self):
         ce = CallbackEvent()
         self.assertEqual(ce.list_name, None)
-        ce.event_payload = get_sample_data('createCard', 'text')
+        ce.event_payload = get_sample_data('createCard', 'json')
         self.assertEqual(ce.list_name, ce.event_payload['action']['data']['list']['name'])  # noqa
 
     def test_card_name(self):
         ce = CallbackEvent()
         self.assertEqual(ce.card_name, None)
-        ce.event_payload = get_sample_data('createCard', 'text')
+        ce.event_payload = get_sample_data('createCard', 'json')
         self.assertEqual(ce.card_name, ce.event_payload['action']['data']['card']['name'])  # noqa


### PR DESCRIPTION
Added new functionalities to *trello_webhooks* and *test_app* to resolve attachment content type.

These include below changes:
- add **attachment** property
- add **update_attachment_content_type** method, which issues a HEAD call and determine attachment's content type
- add new template filter **attachment_name_or_inline_image** under **test_app** to render either attachment name as text or inline image html depending on attachment content_type
- add tests (also include a few tests for **test_app** to improve overall coverage)
- add sample data **addAttachmentToCard.json** for testing (taken from Trello API docs)
- add new management command **update_callbackevent_content_type** to reconcile all existing records
- update *requirements.txt* with "Django==1.8"

## Update (as of 14th May)

- resolve dependencies in *requirements.txt* for upgrading to Django1.8
- update tests and models with package new API


## Notes

### Upgrade to Django1.8

The reasons of my upgrading to Django1.8 are based on a few things:
- Tox.ini targets minimum py27-django1.8;
- Django 1.7 failed to build on my local env due to the psycopg2 dependency (incompatible PostgreSQL version requires a newer package version);
- Latest LTS is already Django 1.11, and the least version mostly supported by other requirement packages is the also outdated Django1.8 (such as jsonfield to support non-psql database), it’s probably the right thing to prepare progressive migration to LTS



Please review.