### PR TITLE
Type specific rendering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 dj-database-url==0.3.0
 django-jsonfield==0.9.13
 git+https://github.com/sarumont/py-trello.git@766c90dc1dacd2e3fcfc579079a6aab38be43aef
-psycopg2==2.5.4
+psycopg2==2.7

--- a/test_app/signals.py
+++ b/test_app/signals.py
@@ -38,7 +38,7 @@ def on_callback_received(sender, **kwargs):
     if settings.HIPCHAT_ENABLED:
         logger.debug(
             u"Message sent to HipChat [%s]: %r",
-            send_to_hipchat(html), event, event.webhook
+            send_to_hipchat(html), (event, event.webhook)
         )
     else:
         logger.debug(

--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,0 +1,2 @@
+{% load trello_webhook_tags %}<strong>{{action.memberCreator.initials}}</strong> added attachment {{action.data.attachment|attachment_html|safe}}
+{% include 'trello_webhooks/partials/card_link.html' %}

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import mock
+
+from django.test import TestCase
+
+from test_app.hipchat import send_to_hipchat
+
+
+class mock_requests_post_return_value:
+    """
+    Fake return value for the mocked requests.post
+    """
+    status_code = 200
+
+
+class HipchatTests(TestCase):
+
+    @mock.patch("requests.post", return_value=mock_requests_post_return_value)
+    def test_send_to_hipchat(self, mock_post):
+        # Check correct information is passed on to requests.post
+        args = {'token': 'abc',
+                'room': 'def',
+                'color': 'ghi',
+                'sender': 'jkl',
+                'notify': 'mno'}
+
+        payload = {
+            'auth_token': 'abc',
+            'notify': 'mno',
+            'color': 'ghi',
+            'from': "jkl",
+            'room_id': "def",
+            'message': "xyz"
+        }
+
+        send_to_hipchat("xyz", **args)
+        mock_post.assert_called_with(
+                    'https://api.hipchat.com/v1/rooms/message',
+                    data=payload)

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -1,6 +1,7 @@
 # # -*- coding: utf-8 -*-
 import json
 import logging
+from mimetypes import MimeTypes
 
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -264,7 +265,10 @@ class CallbackEvent(models.Model):
         )
 
     def save(self, *args, **kwargs):
-        """Update timestamp"""
+        """Add 'content-type' to attachment (if it exists) and update timestamp"""
+        if self.attachment:
+            content_type = MimeTypes().guess_type(self.attachment.get('name'))[0]
+            self.attachment['content-type'] = content_type
         self.timestamp = timezone.now()
         super(CallbackEvent, self).save(*args, **kwargs)
         return self
@@ -293,6 +297,11 @@ class CallbackEvent(models.Model):
     def card(self):
         """Returns 'card' JSON extracted from event_payload."""
         return self.action_data.get('card') if self.action_data else None
+
+    @property
+    def attachment(self):
+        """Returns 'attachment' JSON extracted from event_payload."""
+        return self.action_data.get('attachment') if self.action_data else None
 
     @property
     def member_name(self):

--- a/trello_webhooks/templatetags/trello_webhook_tags.py
+++ b/trello_webhooks/templatetags/trello_webhook_tags.py
@@ -52,3 +52,16 @@ def trello_updates(new, old):
         return {k: (v, new[k]) for k, v in old.iteritems()}
     except KeyError:
         return {k: (v, None) for k, v in old.iteritems()}
+
+
+@register.filter
+def attachment_html(attachment_data):
+    """
+    Return appropriate HTML to render link to attachment dependent
+    upon the content-type of the attachment.
+    """
+    url = attachment_data.get('url')
+    name = attachment_data.get('name')
+    if attachment_data.get('content-type')[:6] == 'image/':
+        return "<br/><a href='%s'><img src='%s'></a>" % (url, url)
+    return '"<strong><a href="%s">%s</a></strong>"' % (url, name)

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,138 @@
+{
+    "action": {
+        "data": {
+            "attachment": {
+                "id": "5ba2b83313c5a72076371c00",
+                "name": "Celery_LOH.png",
+                "previewUrl": "https://trello-attachments.s3.amazonaws.com/58b33ad519fbe30139f548b3/5ba288e78edd826f69cbc417/ec31f43bbf57b29b2c27f7d3eb7ffcf7/Celery_LOH.png",
+                "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/58b33ad519fbe30139f548b3/5ba288e78edd826f69cbc417/ec31f43bbf57b29b2c27f7d3eb7ffcf7/Celery_LOH.png",
+                "url": "https://trello-attachments.s3.amazonaws.com/58b33ad519fbe30139f548b3/5ba288e78edd826f69cbc417/ec31f43bbf57b29b2c27f7d3eb7ffcf7/Celery_LOH.png"
+            },
+            "board": {
+                "id": "58b33ad519fbe30139f548b3",
+                "name": "House stuff",
+                "shortLink": "raZWC9yN"
+            },
+            "card": {
+                "id": "5ba288e78edd826f69cbc417",
+                "idShort": 19,
+                "name": "weqweqwe",
+                "shortLink": "4LhDXwYM"
+            },
+            "list": {
+                "id": "5ba288e52453d342135ecb50",
+                "name": "werwerw"
+            }
+        },
+        "date": "2018-09-19T20:57:23.196Z",
+        "display": {
+            "entities": {
+                "attachment": {
+                    "id": "5ba2b83313c5a72076371c00",
+                    "link": true,
+                    "previewUrl": "https://trello-attachments.s3.amazonaws.com/58b33ad519fbe30139f548b3/5ba288e78edd826f69cbc417/ec31f43bbf57b29b2c27f7d3eb7ffcf7/Celery_LOH.png",
+                    "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/58b33ad519fbe30139f548b3/5ba288e78edd826f69cbc417/ec31f43bbf57b29b2c27f7d3eb7ffcf7/Celery_LOH.png",
+                    "text": "Celery_LOH.png",
+                    "type": "attachment",
+                    "url": "https://trello-attachments.s3.amazonaws.com/58b33ad519fbe30139f548b3/5ba288e78edd826f69cbc417/ec31f43bbf57b29b2c27f7d3eb7ffcf7/Celery_LOH.png"
+                },
+                "attachmentPreview": {
+                    "id": "5ba2b83313c5a72076371c00",
+                    "originalUrl": "https://trello-attachments.s3.amazonaws.com/58b33ad519fbe30139f548b3/5ba288e78edd826f69cbc417/ec31f43bbf57b29b2c27f7d3eb7ffcf7/Celery_LOH.png",
+                    "previewUrl": "https://trello-attachments.s3.amazonaws.com/58b33ad519fbe30139f548b3/5ba288e78edd826f69cbc417/ec31f43bbf57b29b2c27f7d3eb7ffcf7/Celery_LOH.png",
+                    "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/58b33ad519fbe30139f548b3/5ba288e78edd826f69cbc417/ec31f43bbf57b29b2c27f7d3eb7ffcf7/Celery_LOH.png",
+                    "type": "attachmentPreview"
+                },
+                "card": {
+                    "id": "5ba288e78edd826f69cbc417",
+                    "shortLink": "4LhDXwYM",
+                    "text": "weqweqwe",
+                    "type": "card"
+                },
+                "memberCreator": {
+                    "id": "58b33aa6ba23e576e8ba7ad1",
+                    "text": "Tim mccurrach",
+                    "type": "member",
+                    "username": "timmccurrach"
+                }
+            },
+            "translationKey": "action_add_attachment_to_card"
+        },
+        "id": "5ba2b83313c5a72076371c02",
+        "idMemberCreator": "58b33aa6ba23e576e8ba7ad1",
+        "limits": {},
+        "memberCreator": {
+            "avatarHash": null,
+            "avatarUrl": null,
+            "fullName": "Tim mccurrach",
+            "id": "58b33aa6ba23e576e8ba7ad1",
+            "initials": "TM",
+            "username": "timmccurrach"
+        },
+        "type": "addAttachmentToCard"
+    },
+    "model": {
+        "avatarHash": null,
+        "avatarSource": "none",
+        "avatarUrl": null,
+        "bio": "",
+        "bioData": null,
+        "confirmed": true,
+        "email": null,
+        "fullName": "Tim mccurrach",
+        "gravatarHash": "29473460bbc1b265961d33279d837412",
+        "id": "58b33aa6ba23e576e8ba7ad1",
+        "idBoards": [
+            "58b33aa6ba23e576e8ba7ad2",
+            "58b33ad519fbe30139f548b3"
+        ],
+        "idBoardsPinned": null,
+        "idEnterprise": null,
+        "idEnterprisesAdmin": [],
+        "idEnterprisesDeactivated": [],
+        "idOrganizations": [],
+        "idPremOrgsAdmin": [],
+        "initials": "TM",
+        "limits": {
+            "boards": {
+                "totalPerMember": {
+                    "disableAt": 4275,
+                    "status": "ok",
+                    "warnAt": 4050
+                }
+            },
+            "orgs": {
+                "totalPerMember": {
+                    "disableAt": 808,
+                    "status": "ok",
+                    "warnAt": 765
+                }
+            }
+        },
+        "loginTypes": null,
+        "marketingOptIn": {
+            "date": "2018-09-18T22:52:26.928Z",
+            "optedIn": true
+        },
+        "memberType": "normal",
+        "messagesDismissed": [],
+        "oneTimeMessagesDismissed": [
+            "quick-team-create"
+        ],
+        "prefs": {
+            "colorBlind": false,
+            "locale": "en-US",
+            "minutesBeforeDeadlineToNotify": 1440,
+            "minutesBetweenSummaries": 1,
+            "sendSummaries": true
+        },
+        "premiumFeatures": [],
+        "products": [],
+        "status": "disconnected",
+        "trophies": [],
+        "uploadedAvatarHash": null,
+        "uploadedAvatarUrl": null,
+        "url": "https://trello.com/timmccurrach",
+        "username": "timmccurrach"
+    }
+}

--- a/trello_webhooks/tests/test_models.py
+++ b/trello_webhooks/tests/test_models.py
@@ -260,7 +260,14 @@ class CallbackEventModelTest(TestCase):
         pass
 
     def test_save(self):
-        pass
+        # check that if there is an attachment that it's content-type is
+        # added to event_payload
+        body_text = get_sample_data('addAttachmentToCard', 'text')
+        w = Webhook().save(sync=False)
+        ce = w.add_callback(body_text)
+        ce.save()
+        self.assertEqual("image/png",
+                         ce.event_payload['action']['data']['attachment']['content-type'])
 
     def test_action_data(self):
         ce = CallbackEvent()
@@ -291,6 +298,12 @@ class CallbackEventModelTest(TestCase):
         self.assertEqual(ce.card, None)
         ce.event_payload = get_sample_data('createCard', 'text')
         self.assertEqual(ce.card, ce.event_payload['action']['data']['card'])
+
+    def test_attachment(self):
+        ce = CallbackEvent()
+        self.assertEqual(ce.attachment, None)
+        ce.event_payload = get_sample_data('addAttachmentToCard', 'test')
+        self.assertEqual(ce.attachment, ce.event_payload['action']['data']['attachment'])
 
     def test_member_name(self):
         ce = CallbackEvent()

--- a/trello_webhooks/tests/test_templatetags.py
+++ b/trello_webhooks/tests/test_templatetags.py
@@ -4,7 +4,8 @@ from django.test import TestCase
 from trello_webhooks.settings import TRELLO_API_KEY
 from trello_webhooks.templatetags.trello_webhook_tags import (
     trello_api_key,
-    trello_updates
+    trello_updates,
+    attachment_html
 )
 
 
@@ -27,4 +28,19 @@ class TemplateTagTests(TestCase):
         self.assertEqual(
             trello_updates(new, old),
             {'pos': (1, None)}
+        )
+
+    def test_attachment_html(self):
+        # attachment is image
+        data = {'name': 'abc', 'url': 'xyz', 'content-type': 'image/png'}
+        self.assertEqual(
+            attachment_html(data),
+            "<br/><a href='xyz'><img src='xyz'></a>"
+        )
+
+        # attachment is not an image
+        data = {'name': 'abc', 'url': 'xyz', 'content-type': 'text/plain'}
+        self.assertEqual(
+            attachment_html(data),
+            '"<strong><a href="xyz">abc</a></strong>"'
         )


### PR DESCRIPTION
Notes on commits:

**Update psycopg2 to version 2.7 in requirements**
Installing `requirements` gave me this error: https://github.com/psycopg/psycopg2/issues/594 I don't know if other users of this repo have faced this problem, but I updated the requirements to 2.7 as suggested.

**Add test for hitchat (sorry for the typo)**
HipChat seems to be discontinued, and I couldn't find a way of setting up an account, but from the experimentation I did using mock values, the following line causes trouble (since two many arguments are provided):
```
        logger.debug(
            u"Message sent to HipChat [%s]: %r",
            send_to_hipchat(html), event, event.webhook
        )
```
In the readme, it is suggested that the `on_callback_received` actually starts differently, and the `send_to_hipchat` function is called outside `logger.debug`. Perhaps this has just not been updated on the master branch?
